### PR TITLE
Fix memory corruption

### DIFF
--- a/orkaudio/filters/LiveStream/LiveStreamFilter.cpp
+++ b/orkaudio/filters/LiveStream/LiveStreamFilter.cpp
@@ -57,29 +57,29 @@ void LiveStreamFilter::AudioChunkIn(AudioChunkRef & inputAudioChunk) {
 
     if (silentChannelBuffer == NULL){
         silentChannelBuffer = (char *)malloc(inputDetails.m_numBytes);
-        if (!silentChannelBuffer) {   
+        if (!silentChannelBuffer) {
             CStdString logMsg;
             logMsg.Format("LiveStreamFilter::AudioChunkIn [%s] SilentChannelBuffer Memory allocation failed.", m_orkRefId);
             LOG4CXX_ERROR(s_log, logMsg);
             return;
         }
-        std::fill_n(silentChannelBuffer, inputDetails.m_numBytes, 0);
+        std::fill_n(silentChannelBuffer, inputDetails.m_numBytes, 255);
     }
 
     if (status) {
         if (inputDetails.m_channel == headChannel) {
-            if (auto elem = bufferQueue.put(inputBuffer)){
-                PushToRTMP(inputDetails, silentChannelBuffer, *elem);
+            if (auto elem = bufferQueue.put(inputAudioChunk)){
+                PushToRTMP(inputDetails, silentChannelBuffer, (char *)(*elem)->m_pBuffer);
             }
         } else {
             if (auto elem = bufferQueue.get()){
-                PushToRTMP(inputDetails, inputBuffer, *elem);
+                PushToRTMP(inputDetails, inputBuffer, (char *)(*elem)->m_pBuffer);
             } else {
                 PushToRTMP(inputDetails, inputBuffer, silentChannelBuffer);
             }
         }
     }
-    
+
 }
 
 void LiveStreamFilter::PushToRTMP(AudioChunkDetails& channelDetails, char * firstChannelBuffer, char * secondChannelBuffer) {
@@ -280,7 +280,7 @@ void LiveStreamFilter::SetSessionInfo(CStdString & trackingId) {
     LOG4CXX_INFO(s_log, "LiveStream SetSessionInfo " + trackingId);
 }
 
- 
+
 // =================================================================
 
 extern "C"

--- a/orkaudio/filters/LiveStream/LiveStreamFilter.h
+++ b/orkaudio/filters/LiveStream/LiveStreamFilter.h
@@ -50,7 +50,7 @@ class DLL_IMPORT_EXPORT_ORKBASE LiveStreamFilter : public Filter {
         unsigned char headChannel;
         srs_rtmp_t rtmp = NULL;
         u_int32_t timestamp = 0;
-        RingBuffer<char *> bufferQueue;
+        RingBuffer<AudioChunkRef> bufferQueue;
         bool shouldStreamAllCalls;
         char * silentChannelBuffer = NULL;
         void PushToRTMP(AudioChunkDetails& channelDetails, char* firstChannelBuffer, char* secondChannelBuffer);


### PR DESCRIPTION
We have been experiencing an issue where the RTMP audio stream is occasionally corrupted during the Live Streaming function. Upon investigating this problem, we found that one of the channels of the AudioChunk is released from memory before the RTMP stream transmission occurs. As a solution, we decided to change the type held by the RingBuffer to AudioChunkRef. Additionally, we have changed the silent buffer from 0x00 to 0xFF. The silence in G711 should be 0xFF.